### PR TITLE
#4 ヘッダーメニュー内'アカウント'のドロップダウンが効いていない

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,2 +1,19 @@
 @import "bootstrap-sprockets";
 @import "bootstrap";
+
+.dropdown-menu {
+  display: none;
+  position: absolute;
+  background-color: #f9f9f9;
+  min-width: 160px;
+  box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
+  z-index: 1;
+  }
+  
+  .dropdown-menu li {
+  padding: 8px 12px;
+  }
+  
+  .dropdown:hover .dropdown-menu {
+  display: block;
+  }

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -45,7 +45,7 @@ Rails.application.configure do
   config.action_mailer.delivery_method = :smtp
 
   host = 'rails_app_no3-1.onrender.com'
-  config.action_mailer.default_url_options = { host: host, protocol: 'https' }
+  config.action_mailer.default_url_options = { host: host }
 
   ActionMailer::Base.smtp_settings = {
     :port           => 587,


### PR DESCRIPTION
## チケットへのリンク

* #5 

## やったこと

* このプルリクで何をしたのか？
ヘッダー内メニューの`アカウント`にCSSを追加してドロップダウンを効かせる

## やらないこと

* このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。）
なし

## できるようになること（ユーザ目線）

* 何ができるようになるのか？（あれば。無いなら「無し」でOK）
`アカウント`にカーソルを合わせると、プロフィール・アカウント情報編集・ログアウトが表示され、クリックすることで飛ぶことができる

## できなくなること（ユーザ目線）

* 何ができなくなるのか？（あれば。無いなら「無し」でOK）
なし

## 動作確認

* どのような動作確認を行ったのか？　結果はどうか？
bootstrap導入前のCSSそのまま追加することで動作することが確認できた。

## その他

* レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）